### PR TITLE
色調反転と画像の名前付け、新しいPDFファイルの追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,15 @@
 import os
 import argparse
 from util import *
+import glob
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--pdf_file', type=str, default='PDF/sample.pdf')
+parser.add_argument('--pdf_file', type=str, default='PDF/*')
 parser.add_argument('--save_dir', type=str, default='Images')
 args = parser.parse_args()
 
 def main(args):
-     #take from all pdf files
+    #take from all pdf files
     for pdf_fl in glob.glob(args.pdf_file):
         pymupdf = PyMuPDF(pdf_fl)
         images = pymupdf.crop_imgs_from_pdf()

--- a/main.py
+++ b/main.py
@@ -8,10 +8,11 @@ parser.add_argument('--save_dir', type=str, default='Images')
 args = parser.parse_args()
 
 def main(args):
-    print('a')
-    pymupdf = PyMuPDF(args.pdf_file)
-    images = pymupdf.crop_imgs_from_pdf()
-    pymupdf.save_images(images, args.save_dir)
+     #take from all pdf files
+    for pdf_fl in glob.glob(args.pdf_file):
+        pymupdf = PyMuPDF(pdf_fl)
+        images = pymupdf.crop_imgs_from_pdf()
+        pymupdf.save_images(images, args.save_dir)
 
 if __name__ == '__main__':
     main(args)


### PR DESCRIPTION
色調反転に関しては
`fitz.colorspace,name == "DeviceCMYK"`

の時である時であるとわかったが、これの解決方法がわからなかった。
その場凌ぎの方法ではあるが、fitz.Pixmap.invert_irectというモジュールで色調反転して保存することで白地に黒の文字になった。（ただ情報が落ちている様に見える）

以前の名前の付け方では重複して画像が上書きされることに気づいたので名前の付け方を変えた。具体的にはmain.pyの方で書類番号を渡しておいてそれを画像の名前に入れた。

またsample.pdf以外にもう一つpdfを追加した。

以上、一つのissueで色々やりすぎました。



